### PR TITLE
TEST: automerge path-gate negative test (do not merge)

### DIFF
--- a/gate-test-322.txt
+++ b/gate-test-322.txt
@@ -1,0 +1,5 @@
+Negative test for the automerge build/ path gate (issue 322).
+
+This file is OUTSIDE build/, on a branch named `translations`. The automerge
+workflow's "Verify every changed file is under build/" step MUST refuse this
+PR (fail, no approval, no merge). Safe to delete.


### PR DESCRIPTION
Deliberate negative test for the automerge `build/` path gate.

Head branch is `translations` (passes the branch gate) but the PR touches a file
OUTSIDE `build/` (`gate-test-322.txt`). The automerge workflow's "Verify every
changed file is under build/" step must **refuse** this: fail, no approval, no merge.

Will be closed and the branch deleted right after the gate is confirmed.

Related: blokadaorg/issue-tracker#322